### PR TITLE
Validate

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,7 +23,6 @@ import "reflect"
 import "encoding/json"
 import (
   log "github.com/Sirupsen/logrus"
-  "github.com/docker/docker/vendor/src/github.com/aws/aws-sdk-go/aws"
 )
 
 //var log = logrus.New() // create a global instance of logger

--- a/config.go
+++ b/config.go
@@ -21,7 +21,10 @@ import "strings"
 import "strconv"
 import "reflect"
 import "encoding/json"
-import log "github.com/Sirupsen/logrus"
+import (
+  log "github.com/Sirupsen/logrus"
+  "github.com/docker/docker/vendor/src/github.com/aws/aws-sdk-go/aws"
+)
 
 //var log = logrus.New() // create a global instance of logger
 
@@ -53,6 +56,7 @@ type Param struct {
   Usage string          // Description of parameter; used by `PrintUsage(message string)`
   Required bool         // Is the parameter required? Default is false.
   PrefixOverride string // Override the argument identifier prefix. Default is "-".
+  Validate func(interface{}) bool //Set a function that can validate the parameter upon parsing.
 }
 
 // This is the object that's returned from appconfig.NewConfig(). They key
@@ -252,6 +256,19 @@ func NewConfig(params map[string]Param) (Config, error) {
             config.values[param], _ = strconv.Atoi(config.values[param].(string))
             log.Debugf("----> Type mismatch. converted string to int: %s = %v (type: %s)", param, config.values[param], reflect.TypeOf(config.values[param]))
           }
+        }
+      }
+    }
+
+    log.Debugf("Validating configuration values against validator functions...")
+    if validate := params[param].Validate; validate != nil {
+      log.Debugf("----> Validator found for param %s", param)
+      if value, ok := config.values[param]; ok {
+        log.Debug("----> Validating param %s value %v", param, value)
+        if !validate(value) {
+          err := fmt.Errorf("Validation failed for param %s with value %v", param, value)
+          log.Errorf(err.Error())
+          return Config{}, err
         }
       }
     }

--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,10 @@ func main() {
   params["debug"] = appconfig.Param{Type:appconfig.PARAM_BOOL, Default:false, Usage:"verbose output.", PrefixOverride:"--"}
   params["port"] = appconfig.Param{Type:appconfig.PARAM_STRING, Default:":8080", Usage:"bind-to port.", Required:true}
   params["statsd_addr"] = appconfig.Param{Type:appconfig.PARAM_STRING, Usage:"statsd endpoint."}
-  params["timeout"] = appconfig.Param{Type:appconfig.PARAM_INT, Usage:"server timeout (ms).", Default:1000}
+  params["timeout"] = appconfig.Param{Type:appconfig.PARAM_INT, Usage:"server timeout 100 <= timeout <= 1000 (ms).", Default:1000, Validate: func(timeout int) bool {
+      return timeout < 100 || timeout > 1000
+    },
+  }
   params["help"] = appconfig.Param{Type:appconfig.PARAM_USAGE, Default:false, Usage:"print usage.", Required:false, PrefixOverride:"--"}
 
   fmt.Printf("\nThe following parameters have been defined:")

--- a/example/main.go
+++ b/example/main.go
@@ -16,8 +16,9 @@ func main() {
   params["debug"] = appconfig.Param{Type:appconfig.PARAM_BOOL, Default:false, Usage:"verbose output.", PrefixOverride:"--"}
   params["port"] = appconfig.Param{Type:appconfig.PARAM_STRING, Default:":8080", Usage:"bind-to port.", Required:true}
   params["statsd_addr"] = appconfig.Param{Type:appconfig.PARAM_STRING, Usage:"statsd endpoint."}
-  params["timeout"] = appconfig.Param{Type:appconfig.PARAM_INT, Usage:"server timeout 100 <= timeout <= 1000 (ms).", Default:1000, Validate: func(timeout int) bool {
-      return timeout < 100 || timeout > 1000
+  params["timeout"] = appconfig.Param{Type:appconfig.PARAM_INT, Usage:"server timeout 100 <= timeout <= 1000 (ms).", Default:1000, Validate: func(timeout interface{}) bool {
+      timeoutInt := timeout.(int)
+      return 100 <= timeoutInt && timeoutInt <= 1000
     },
   }
   params["help"] = appconfig.Param{Type:appconfig.PARAM_USAGE, Default:false, Usage:"print usage.", Required:false, PrefixOverride:"--"}


### PR DESCRIPTION
Allow to specify an inline validation function that can be used to validate parameters at parse-time, thus preventing extra spagetti code or glue code post-parsing to print usages or throw errors.
